### PR TITLE
Automatic ratio evaluation for Stock Split

### DIFF
--- a/app/account.py
+++ b/app/account.py
@@ -119,11 +119,9 @@ class Account:
                 self._realized_change[symbol] = [change]
 
     def _evaluate_stock_split_ratio(self, transaction: Transaction) -> Decimal:
-        ratio = 1
-        if transaction.symbol == "AAPL" and transaction.settle_date.strftime("%Y-%m-%d") == "2020-08-31":
-            ratio = 4
-        if transaction.symbol == "TSLA" and transaction.settle_date.strftime("%Y-%m-%d") == "2020-08-31":
-            ratio = 5
+        position = self._get_position(transaction.symbol)
+        current_quantity = sum([p.quantity for p in position._current_positions])
+        ratio = (current_quantity + transaction.quantity) / current_quantity
         return Decimal(ratio)
 
     def do_transaction(self, transaction: Transaction):

--- a/tests/account_stock_test.py
+++ b/tests/account_stock_test.py
@@ -248,6 +248,61 @@ class TestAccount(unittest.TestCase):
         self.assertEqual(account.get_profit(year=2021), 150)
         self.assertEqual(account.get_tax(year=2021), 28.5)
 
+    def test_evaluate_stock_split(self):
+        exchange = ExchangeMock()
+        account = Account(exchange)
+
+        # Buy 1 TSLA for 100 PLN.
+        account.do_transaction(
+            Transaction(
+                trade_date=datetime(2021, 1, 1),
+                settle_date=datetime(2021, 1, 1),
+                currency=Currency.PLN,
+                activity=Activity.BUY,
+                symbol="TSLA",
+                quantity=Decimal(1),
+                price=Decimal(100),
+                amount=Decimal(100),
+                dividend_tax_deducted=Decimal(0),
+            )
+        )
+
+        # Split stack with ratio 5
+        account.do_transaction(
+            Transaction(
+                trade_date=datetime(2021, 1, 2),
+                settle_date=datetime(2021, 1, 2),
+                currency=Currency.PLN,
+                activity=Activity.SSP,
+                symbol="TSLA",
+                quantity=Decimal(4),  # 1 + 4
+                price=Decimal(0),
+                amount=Decimal(0),
+                dividend_tax_deducted=Decimal(0),
+            )
+        )
+
+        # Sell 5 TSLA for 200 PLN.
+        account.do_transaction(
+            Transaction(
+                trade_date=datetime(2021, 1, 3),
+                settle_date=datetime(2021, 1, 3),
+                currency=Currency.PLN,
+                activity=Activity.SELL,
+                symbol="TSLA",
+                quantity=Decimal(5),
+                price=Decimal(40),
+                amount=Decimal(200),
+                dividend_tax_deducted=Decimal(0),
+            )
+        )
+
+        # Compute profits and taxes.
+        # 200 PLN - 100 PLN = 100 PLN profit.
+        # 100 PLN * 19% = 19 PLN tax.
+        self.assertEqual(account.get_profit(year=2021), 100)
+        self.assertEqual(account.get_tax(year=2021), 19)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hey,

I had a problem with this script because of `Exception: symbol=NVDA: you can't sell stock that you don't own`. Then I figured out that NVidia had stock split. After some digging i discovered that only few stocks are actually calcutating ratio, and those ratios are hardcoded.

Instead of manual ratio input I propose automatic one.

It is tested for Revolut data only, I am not sure how it will behave using "degiro".

